### PR TITLE
Clean up debug logs, add in update checker, QOL camera control enhancement, right click on sims to play them

### DIFF
--- a/Client/Simitone/Simitone.Client/Services/UpdateChecker.cs
+++ b/Client/Simitone/Simitone.Client/Services/UpdateChecker.cs
@@ -1,0 +1,176 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using FSO.Common.Utils;
+using FSO.Client.UI.Framework;
+using FSO.Client.UI.Controls;
+using FSO.Client.UI.Model;
+using FSO.HIT;
+using Simitone.Client.UI.Panels;
+
+namespace Simitone.Client.Services
+{
+    /// <summary>
+    /// Represents a GitHub release from the API response.
+    /// </summary>
+    public class GitHubRelease
+    {
+        [JsonProperty("tag_name")]
+        public string TagName { get; set; }
+
+        [JsonProperty("html_url")]
+        public string HtmlUrl { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("body")]
+        public string Body { get; set; }
+    }
+
+    /// <summary>
+    /// Checks for updates from GitHub releases on startup.
+    /// </summary>
+    public static class UpdateChecker
+    {
+        private static readonly HttpClient _httpClient = new HttpClient();
+        private static bool _hasChecked = false;
+
+        static UpdateChecker()
+        {
+            // GitHub API requires a User-Agent header
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "Simitone-UpdateChecker");
+            _httpClient.Timeout = TimeSpan.FromSeconds(10);
+        }
+
+        /// <summary>
+        /// Checks for updates asynchronously. Safe to call multiple times - only runs once.
+        /// </summary>
+        public static void CheckForUpdatesAsync()
+        {
+            if (_hasChecked) return;
+            _hasChecked = true;
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var response = await _httpClient.GetStringAsync(SimitoneVersion.GitHubReleasesApiUrl);
+                    var release = JsonConvert.DeserializeObject<GitHubRelease>(response);
+
+                    if (release != null && IsNewerVersion(release.TagName))
+                    {
+                        // Marshal back to game thread to show dialog
+                        GameThread.NextUpdate(_ => ShowUpdateDialog(release));
+                    }
+                }
+                catch (Exception)
+                {
+                    // Silently fail - don't interrupt game if update check fails
+                    // This handles: no internet, API errors, JSON parse errors, etc.
+                }
+            });
+        }
+
+        /// <summary>
+        /// Compares version strings to determine if the remote version is newer.
+        /// Handles version formats like "v0.8.19", "0.8.19-forked", etc.
+        /// </summary>
+        private static bool IsNewerVersion(string tagName)
+        {
+            // Normalize version strings: strip 'v' prefix and any suffix after hyphen for comparison
+            var latestVersion = NormalizeVersion(tagName);
+            var currentVersion = NormalizeVersion(SimitoneVersion.Current);
+
+            if (Version.TryParse(latestVersion, out var latest) &&
+                Version.TryParse(currentVersion, out var current))
+            {
+                return latest > current;
+            }
+
+            // Fallback: string comparison if parsing fails
+            return string.Compare(latestVersion, currentVersion, StringComparison.OrdinalIgnoreCase) > 0;
+        }
+
+        /// <summary>
+        /// Normalizes a version string by removing 'v' prefix and extracting the numeric part.
+        /// "v0.8.19-forked" -> "0.8.19"
+        /// </summary>
+        private static string NormalizeVersion(string version)
+        {
+            if (string.IsNullOrEmpty(version)) return "0.0.0";
+
+            // Remove 'v' or 'V' prefix
+            version = version.TrimStart('v', 'V');
+
+            // Remove suffix after hyphen (e.g., "-forked", "-beta")
+            var hyphenIndex = version.IndexOf('-');
+            if (hyphenIndex > 0)
+            {
+                version = version.Substring(0, hyphenIndex);
+            }
+
+            return version;
+        }
+
+        /// <summary>
+        /// Shows the update available dialog to the user.
+        /// </summary>
+        private static void ShowUpdateDialog(GitHubRelease release)
+        {
+            var latestVersion = release.TagName.TrimStart('v', 'V');
+
+            UIMobileAlert alert = null;
+            alert = new UIMobileAlert(new UIAlertOptions
+            {
+                Title = "Update Available",
+                Message = $"A new version of Simitone is available!\n\n" +
+                          $"Current version: {SimitoneVersion.Current}\n" +
+                          $"Latest version: {latestVersion}\n\n" +
+                          $"Would you like to download the update?",
+                Buttons = new UIAlertButton[]
+                {
+                    new UIAlertButton(UIAlertButtonType.Yes, (btn) =>
+                    {
+                        OpenDownloadPage(release.HtmlUrl);
+                        alert.Close();
+                    }, "Download"),
+                    new UIAlertButton(UIAlertButtonType.No, (btn) =>
+                    {
+                        alert.Close();
+                    }, "Skip")
+                }
+            });
+
+            HITVM.Get().PlaySoundEvent(UISounds.CallSend);
+            UIScreen.GlobalShowDialog(alert, true);
+        }
+
+        /// <summary>
+        /// Opens the download page in the default browser.
+        /// </summary>
+        private static void OpenDownloadPage(string url)
+        {
+            try
+            {
+                var psi = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true
+                };
+                System.Diagnostics.Process.Start(psi);
+            }
+            catch (Exception)
+            {
+                // Failed to open browser - not critical, just ignore
+            }
+        }
+    }
+}

--- a/Client/Simitone/Simitone.Client/SimitoneVersion.cs
+++ b/Client/Simitone/Simitone.Client/SimitoneVersion.cs
@@ -1,0 +1,25 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at
+http://mozilla.org/MPL/2.0/.
+*/
+
+namespace Simitone.Client
+{
+    /// <summary>
+    /// Version constants for Simitone.
+    /// Update the Current version for each release.
+    /// </summary>
+    public static class SimitoneVersion
+    {
+        /// <summary>
+        /// The current version of Simitone. Update this for each release.
+        /// </summary>
+        public const string Current = "0.8.19-forked";
+
+        /// <summary>
+        /// GitHub API endpoint for fetching the latest release.
+        /// </summary>
+        public const string GitHubReleasesApiUrl = "https://api.github.com/repos/alexjyong/Simitone/releases/latest";
+    }
+}

--- a/Client/Simitone/Simitone.Client/SimitoneVersion.cs
+++ b/Client/Simitone/Simitone.Client/SimitoneVersion.cs
@@ -15,7 +15,7 @@ namespace Simitone.Client
         /// <summary>
         /// The current version of Simitone. Update this for each release.
         /// </summary>
-        public const string Current = "0.8.19-forked";
+        public const string Current = "0.8.20-forked";
 
         /// <summary>
         /// GitHub API endpoint for fetching the latest release.

--- a/Client/Simitone/Simitone.Client/UI/Panels/UILotControl.cs
+++ b/Client/Simitone/Simitone.Client/UI/Panels/UILotControl.cs
@@ -93,6 +93,10 @@ namespace Simitone.Client.UI.Panels
         private int RMBScrollX;
         private int RMBScrollY;
 
+        private bool MMBScroll;
+        private int MMBScrollX;
+        private int MMBScrollY;
+
         //1 = near, 0.5 = med, 0.25 = far
         //"target" because we rescale the game target to fit this zoom level.
         public float TargetZoom = 1; 
@@ -870,8 +874,56 @@ namespace Simitone.Client.UI.Panels
 
                 if (state.MouseState.RightButton != ButtonState.Pressed)
                 {
-                    if (RMBScroll) GameFacade.Cursor.SetCursor(CursorType.Normal);
+                    if (RMBScroll)
+                    {
+                        GameFacade.Cursor.SetCursor(CursorType.Normal);
+                        // Check if it was a click (not a drag) on a family member Sim
+                        var deltaX = Math.Abs(state.MouseState.X - RMBScrollX);
+                        var deltaY = Math.Abs(state.MouseState.Y - RMBScrollY);
+                        if (deltaX < 5 && deltaY < 5 && LiveMode && ActiveEntity != null)
+                        {
+                            // It was a click - check if clicking on a household Sim
+                            var clickedObjId = World.GetObjectIDAtScreenPos(RMBScrollX, RMBScrollY, GameFacade.GraphicsDevice);
+                            if (clickedObjId > 0)
+                            {
+                                var clickedObj = vm.GetObjectById(clickedObjId);
+                                if (clickedObj is VMAvatar && vm.TS1State.CurrentFamily?.RuntimeSubset.Contains(clickedObj.Object.OBJ.GUID) == true)
+                                {
+                                    // Switch to this family member
+                                    vm.SendCommand(new VMNetChangeControlCmd() { TargetID = clickedObj.ObjectID });
+                                    HITVM.Get().PlaySoundEvent(UISounds.QueueAdd);
+                                }
+                            }
+                        }
+                    }
                     RMBScroll = false;
+                }
+
+                // Middle mouse button handling for camera rotation
+                if (state.MouseState.MiddleButton == ButtonState.Pressed)
+                {
+                    if (!MMBScroll)
+                    {
+                        MMBScroll = true;
+                        MMBScrollX = state.MouseState.X;
+                        MMBScrollY = state.MouseState.Y;
+                    }
+                }
+                else
+                {
+                    if (MMBScroll)
+                    {
+                        // Check if it was a click (not a drag)
+                        var deltaX = Math.Abs(state.MouseState.X - MMBScrollX);
+                        var deltaY = Math.Abs(state.MouseState.Y - MMBScrollY);
+                        if (deltaX < 5 && deltaY < 5)
+                        {
+                            // It was a click - rotate camera 90 degrees clockwise
+                            World.State.Rotation = (WorldRotation)(((int)World.State.Rotation + 1) % 4);
+                            HITVM.Get().PlaySoundEvent(UISounds.ObjectRotate);
+                        }
+                    }
+                    MMBScroll = false;
                 }
 
                 if (!LiveMode && PieMenu != null)

--- a/Client/Simitone/Simitone.Client/UI/Panels/UILotControl.cs
+++ b/Client/Simitone/Simitone.Client/UI/Panels/UILotControl.cs
@@ -920,7 +920,7 @@ namespace Simitone.Client.UI.Panels
                         {
                             // It was a click - rotate camera 90 degrees clockwise
                             World.State.Rotation = (WorldRotation)(((int)World.State.Rotation + 1) % 4);
-                            HITVM.Get().PlaySoundEvent(UISounds.ObjectRotate);
+                            HITVM.Get().PlaySoundEvent(UISounds.Click);
                         }
                     }
                     MMBScroll = false;

--- a/Client/Simitone/Simitone.Client/UI/Panels/UILotControl.cs
+++ b/Client/Simitone/Simitone.Client/UI/Panels/UILotControl.cs
@@ -891,7 +891,10 @@ namespace Simitone.Client.UI.Panels
                                 {
                                     // Switch to this family member
                                     vm.SendCommand(new VMNetChangeControlCmd() { TargetID = clickedObj.ObjectID });
-                                    HITVM.Get().PlaySoundEvent(UISounds.QueueAdd);
+                                    // Update local state immediately so interactions work right away
+                                    ActiveEntity = clickedObj;
+                                    Queue.QueueOwner = ActiveEntity;
+                                    HITVM.Get().PlaySoundEvent(UISounds.Click);
                                 }
                             }
                         }

--- a/Client/Simitone/Simitone.Client/UI/Screens/TS1GameScreen.cs
+++ b/Client/Simitone/Simitone.Client/UI/Screens/TS1GameScreen.cs
@@ -30,6 +30,7 @@ using Simitone.Client.UI.Controls;
 using Simitone.Client.UI.Panels;
 using Simitone.Client.UI.Panels.WorldUI;
 using Simitone.Client.Utils;
+using Simitone.Client.Services;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -195,6 +196,9 @@ namespace Simitone.Client.UI.Screens
             if (Content.Get().TS1)
             {
                 NeighSelection(mode);
+
+                // Check for updates from GitHub releases
+                UpdateChecker.CheckForUpdatesAsync();
             }
         }
         public int? MoveInFamily;


### PR DESCRIPTION
This pull request introduces two main improvements: a user-friendly update checker that notifies users of new Simitone releases via GitHub, and a quality-of-life camera control enhancement. The update checker runs on startup, compares the current version to the latest release, and prompts the user to download updates if available. Additionally, users can now rotate the camera 90 degrees by clicking the middle mouse button or select different playable sims by right clicking on them. 

Also removed some debug code and unneeded code.